### PR TITLE
fix AccountsStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minecraft-auth",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minecraft-auth",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "atob": "^2.1.2",

--- a/src/AccountStorage.ts
+++ b/src/AccountStorage.ts
@@ -10,7 +10,7 @@ export class AccountsStorage {
 
     }
 
-    getAccount(index:number): Account {
+    getAccount(index:number): Account | undefined {
         return this.accountList[index];
     }
 

--- a/src/AccountStorage.ts
+++ b/src/AccountStorage.ts
@@ -15,21 +15,15 @@ export class AccountsStorage {
     }
 
     getAccountByUUID(uuid:string): Account | undefined {
-        let acc = undefined;
-        this.accountList.forEach((el: Account) => {
-            if (el.uuid === uuid) {
-                acc = el;
-            }
+        const acc = this.accountList.find((el: Account) => {
+            return el.uuid === uuid;
         })
         return acc;
     }
 
     getAccountByName(name:string): Account | undefined {
-        let acc = undefined;
-        this.accountList.forEach((el: Account) => {
-            if (el.username === name) {
-                acc = el;
-            }
+        const acc = this.accountList.find((el: Account) => {
+            return el.username === name;
         })
         return acc;
     }


### PR DESCRIPTION
Add `undefined` to the return type of the method `getAccount`

Use `find` instead of `forEach` for the `getAccountByName` and `getAccountByUUID` methods