### PR TITLE
Close keep alive connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minecraft-auth",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minecraft-auth",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "atob": "^2.1.2",
@@ -23,6 +23,9 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "bugs": {
     "url": "https://github.com/dommilosz/minecraft-auth/issues"
   },
+  "engines": {
+    "node": ">=18.2.0"
+  },
   "dependencies": {
     "atob": "^2.1.2",
     "http-client-methods": "^1.0.4"

--- a/src/MicrosoftAuth/MicrosoftAuth.ts
+++ b/src/MicrosoftAuth/MicrosoftAuth.ts
@@ -59,6 +59,7 @@ async function createServer(serverConfig: ServerConfigType): Promise<ListeningHt
                 server.serverTimeout = undefined
             }
 
+            server.closeAllConnections()
             await server.close();
         };
 
@@ -105,6 +106,8 @@ async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerC
                     await res.end(createUrl());
                     break;
                 case '/close':
+                    res.writeHead(200)
+                    res.end()
                     await server.fullClose(false);
                     j(undefined);
                     break;

--- a/tests/microsoftAuthServer.test.ts
+++ b/tests/microsoftAuthServer.test.ts
@@ -25,6 +25,44 @@ test("Microsoft Auth: /url endpoint", async () => {
     expect(url).toStrictEqual(MicrosoftAuth.createUrl());
 })
 
+test("Microsoft Auth: /close endpoint", async () => {
+    let callbackExecuted = false;
+
+    let p = MicrosoftAuth.listenForCode({
+        timeout: 500,
+        onclose: (success) => {
+            expect(success).toBeFalsy();
+            callbackExecuted = true;
+        }
+    }).catch(_ => {
+    });
+
+    await HttpGet("http://localhost:8080/close");
+    await p;
+
+    expect(callbackExecuted).toBeTruthy();
+})
+
+test("Microsoft Auth: /close endpoint with a keep-alive connection", async () => {
+    let callbackExecuted = false;
+
+    let p = MicrosoftAuth.listenForCode({
+        timeout: 500,
+        onclose: (success) => {
+            expect(success).toBeFalsy();
+            callbackExecuted = true;
+        }
+    }).catch(_ => {
+    });
+
+    await HttpGet("http://localhost:8080/close", {
+        "Connection": "keep-alive"
+    }, true);
+    await p;
+
+    expect(callbackExecuted).toBeTruthy();
+})
+
 test("Microsoft Auth: Redirect test", async () => {
     let code = MicrosoftAuth.listenForCode({timeout: 500}).catch(_ => {
     });


### PR DESCRIPTION
The server for Microsoft Authentification take long time for closing when keeping the tab opening in a browser, this is due to the `Connetion: keep-alive` header used by the browser, see nodejs/node#2642. For fixing this, the simplest solution would be to force close all the connections in the `fullClose` method, but this require NodeJS >= 18.2.0.