### PR TITLE
Disable keep-alive connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/dommilosz/minecraft-auth/issues"
   },
   "engines": {
-    "node": ">=18.2.0"
+    "node": "^18 || ^20"
   },
   "dependencies": {
     "atob": "^2.1.2",

--- a/src/MicrosoftAuth/MicrosoftAuth.ts
+++ b/src/MicrosoftAuth/MicrosoftAuth.ts
@@ -59,7 +59,6 @@ async function createServer(serverConfig: ServerConfigType): Promise<ListeningHt
                 server.serverTimeout = undefined
             }
 
-            server.closeAllConnections()
             await server.close();
         };
 
@@ -76,6 +75,8 @@ async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerC
 
         async function requestListener(req: IncomingMessage, res: ServerResponse) {
             if (!req.url) return;
+
+            res.setHeader("Connection", "close")
 
             switch (req.url.split('?')[0]) {
                 case '/token':


### PR DESCRIPTION
Apply the suggestion made here https://github.com/dommilosz/minecraft-auth/issues/24#issuecomment-1864917370

Why the workflow run only on master and pull-request ?