### PR TITLE
Fix microsoft auth server tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  clearMocks: true,
   preset: 'ts-jest',
   testEnvironment: 'node',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,18 @@
 {
   "name": "minecraft-auth",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minecraft-auth",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
-        "atob": "^2.1.2",
         "http-client-methods": "^1.0.4"
       },
       "devDependencies": {
         "@tsconfig/node16": "^16.1.1",
-        "@types/atob": "^2.1.2",
         "@types/jest": "^29.5.5",
         "@types/node": "^20.8.3",
         "jest": "^29.7.0",
@@ -25,7 +23,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=18.2.0"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1090,12 +1088,6 @@
       "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
       "dev": true
     },
-    "node_modules/@types/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==",
-      "dev": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
@@ -1299,17 +1291,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/babel-jest": {

--- a/src/MicrosoftAuth/MicrosoftAuth.ts
+++ b/src/MicrosoftAuth/MicrosoftAuth.ts
@@ -51,7 +51,7 @@ async function createServer(serverConfig: ServerConfigType): Promise<ListeningHt
             j(err);
         })
 
-        server.fullClose = async function (success: boolean) {
+        server.fullClose = function (success: boolean) {
             _success = success;
 
             if (server.serverTimeout) {
@@ -59,7 +59,7 @@ async function createServer(serverConfig: ServerConfigType): Promise<ListeningHt
                 server.serverTimeout = undefined
             }
 
-            await server.close();
+            server.close();
         };
 
         return server;
@@ -69,7 +69,7 @@ async function createServer(serverConfig: ServerConfigType): Promise<ListeningHt
 async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerConfigType): Promise<string> {
     return await new Promise<string>((r, j) => {
         server.serverTimeout = setTimeout(async () => {
-            await server.fullClose(false);
+            server.fullClose(false);
             j("Timeout error");
         }, serverConfig.timeout);
 
@@ -81,12 +81,12 @@ async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerC
             switch (req.url.split('?')[0]) {
                 case '/token':
                     if (serverConfig.redirectAfterAuth) {
-                        await res.writeHead(301, {
+                        res.writeHead(301, {
                             Location: serverConfig.redirectAfterAuth,
                         });
                     }
-                    await res.end();
-                    await server.fullClose(true);
+                    res.end();
+                    server.fullClose(true);
                     if (req.url.includes('?code')) {
                         let code = req.url.split('?code=')[1];
                         if (serverConfig.oncode) {
@@ -103,13 +103,13 @@ async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerC
                     }
                     break;
                 case '/url':
-                    await res.writeHead(200);
-                    await res.end(createUrl());
+                    res.writeHead(200);
+                    res.end(createUrl());
                     break;
                 case '/close':
                     res.writeHead(200)
                     res.end()
-                    await server.fullClose(false);
+                    server.fullClose(false);
                     j(undefined);
                     break;
                 case '/auth':

--- a/src/MicrosoftAuth/MicrosoftAuth.ts
+++ b/src/MicrosoftAuth/MicrosoftAuth.ts
@@ -127,7 +127,7 @@ async function _listenForCode(server: ListeningHttpServer, serverConfig: ServerC
                     res.writeHead(200)
                     res.end()
                     server.fullClose(false);
-                    j(undefined);
+                    j("Closed");
                     break;
                 case '/auth':
                     res.writeHead(302, {

--- a/src/MicrosoftAuth/MicrosoftAuth.types.ts
+++ b/src/MicrosoftAuth/MicrosoftAuth.types.ts
@@ -7,6 +7,7 @@ export type MSConfigType = {
 }
 
 export type ServerConfigType = {
+    abort?: AbortSignal;
     port: number,
     host: string,
     redirectAfterAuth?: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import http from "http";
 
 export type ListeningHttpServer = http.Server & {
+    abort?: () => void;
     fullClose: (success:boolean) => void;
     serverTimeout?: NodeJS.Timeout;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import http from "http";
 
 export type ListeningHttpServer = http.Server & {
-    fullClose: (success:boolean) => any;
+    fullClose: (success:boolean) => void;
     serverTimeout?: NodeJS.Timeout;
 };
 export type AccountType = "mojang" | "cracked" | "microsoft" | "token";

--- a/tests/microsoftAuthServer.test.ts
+++ b/tests/microsoftAuthServer.test.ts
@@ -128,7 +128,7 @@ test("Microsoft Auth: Test onstart on error condition", async () => {
 
     await expect(MicrosoftAuth.listenForCode({
         onstart: secondOnStart
-    })).rejects.toThrowError("listen EADDRINUSE: address already in use 127.0.0.1:8080")
+    })).rejects.toThrowError(/listen EADDRINUSE: address already in use (127.0.0.1|::1):8080/)
 
     expect(onStart).toBeCalledTimes(1)
     expect(onStart).toBeCalledWith("localhost", 8080)


### PR DESCRIPTION
I have rewrited the tests for microsoftAuth using `jest.fn` for callbacks and jest promise API for promises. This made the tests more clear and compact. I have also added the `abort` option to the `listenForCode` function to add the possibility to close the server without waiting for code or timeout.